### PR TITLE
Fix: Remove import of libs (google/firebase)

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import androidx.annotation.NonNull; // new
 import androidx.annotation.Nullable; // new
 import androidx.core.app.NotificationManagerCompat;
 
@@ -33,9 +32,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import android.util.Log;
-
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
 
 public class RNPushNotification extends ReactContextBaseJavaModule implements ActivityEventListener {
     public static final String LOG_TAG = "RNPushNotification";// all logging should use this tag

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -413,12 +413,6 @@ public class RNPushNotificationHelper {
             bundle.putBoolean("userInteraction", true);
             intent.putExtra("notification", bundle);
 
-            // Add message_id to intent so react-native-firebase/messaging can identify it
-            String messageId = bundle.getString("messageId");
-            if (messageId != null) {
-                intent.putExtra("message_id", messageId);
-            }
-
             Uri soundUri = null;
 
             if (!bundle.containsKey("playSound") || bundle.getBoolean("playSound")) {
@@ -525,9 +519,6 @@ public class RNPushNotificationHelper {
                     bundle.putString("action", action);
                     actionIntent.putExtra("notification", bundle);
                     actionIntent.setPackage(packageName);
-                    if (messageId != null) {
-                        intent.putExtra("message_id", messageId);
-                    }
 
                     int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "android",
     "notifications",
     "push",
-    "apns",
-    "firebase"
+    "apns"
   ],
   "bugs": {
     "url": "https://github.com/zo0r/react-native-push-notification/issues"


### PR DESCRIPTION
I ran into these error msgs:
```

> Task :react-native-push-notification:compileDebugJavaWithJavac FAILED
128 actionable tasks: 6 executed, 122 up-to-date

/drip/node_modules/react-native-push-notification/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java:37: error: package com.google.android.gms.tasks does not exist
import com.google.android.gms.tasks.OnCompleteListener; 

/drip/node_modules/react-native-push-notification/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java:38: error: package com.google.android.gms.tasks does not exist
import com.google.android.gms.tasks.Task;
```

and found more firebase souvenirs along the way.