### PR TITLE
Fix: Bring back requestPermissions()

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -129,6 +129,25 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void requestPermissions() {
+      final RNPushNotificationJsDelivery fMjsDelivery = mJsDelivery;
+      
+      FirebaseMessaging.getInstance().getToken()
+              .addOnCompleteListener(new OnCompleteListener<String>() {
+                  @Override
+                  public void onComplete(@NonNull Task<String> task) {
+                      if (!task.isSuccessful()) {
+                          Log.e(LOG_TAG, "exception", task.getException());
+                          return;
+                      }
+                      WritableMap params = Arguments.createMap();
+                      params.putString("deviceToken", task.getResult());
+                      fMjsDelivery.sendEvent("remoteNotificationsRegistered", params);
+                  }
+              });
+    }
+
+    @ReactMethod
     public void presentLocalNotification(ReadableMap details) {
         Bundle bundle = Arguments.toBundle(details);
         // If notification ID is not provided by the user, generate one at random


### PR DESCRIPTION
Running into error messages like this, and seeing that we had this code in the fork before I brought it back here:

```
 ERROR  TypeError: RNPushNotification.requestPermissions is not a function. (In 'RNPushNotification.requestPermissions()', 'RNPushNotification.requestPermissions' is undefined)

This error is located at:
    in App (at app-wrapper.js:48)
    in AppWrapper (at renderApplication.js:50)
    in RCTView (at View.js:32)
    in View (at AppContainer.js:92)
    in RCTView (at View.js:32)
    in View (at AppContainer.js:119)
    in AppContainer (at renderApplication.js:43)
    in drip(RootComponent) (at renderApplication.js:60)
```